### PR TITLE
Add Ether and Bitcoin Cash.

### DIFF
--- a/src/Network/Bitcoin/BitX/Types.hs
+++ b/src/Network/Bitcoin/BitX/Types.hs
@@ -188,6 +188,7 @@ data CcyPair =
     | XBTMYR -- ^ Bitcoin vs. Malaysian Ringgit
     | XBTNGN -- ^ Bitcoin vs. Nigerian Naira
     | XBTIDR -- ^ Bitcoin vs. Indonesian Rupiah
+    | ETHXBT -- ^ Ether vs. Bitcoin
   deriving (Show, Generic, Eq, Data, Typeable, Ord)
 
 instance NFData CcyPair
@@ -214,6 +215,8 @@ data Asset =
     | XBT -- ^ Bitcoin
     | MYR -- ^ Malaysian Ringgit
     | IDR -- ^ Indonesian Rupiah
+    | BCH -- ^ Bitcoin Cash
+    | ETH -- ^ Ether
   deriving (Show, Generic, Eq, Data, Typeable, Ord)
 
 instance NFData Asset


### PR DESCRIPTION
Closes #5.

As far as I can tell, nothing else is needed beyond adding these to their respective enums.

I snuck the BCH asset in here as well, because since my account has a BCH wallet, various responses were failing to parse due to the unrecognized asset. (There are no BCH pairs, and you cannot create a receiving address for BCH, but you can view balances / transactions and send BCH out; you would have a BCH balance if you had XBT at the moment the BCH fork happened)

Note that the ETHXBT pair is sort of hidden at the moment; it hasn't been announced yet, and does not show up in the list of all tickers, but is otherwise fully functional (you can still request the ticker for it directly, and trading works just fine).