### PR TITLE
Share the global manager rather than recreating it all the time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ script:
       cabal configure --enable-tests
 
       echo -e "\033[0;32mcabal build.\033[0m"
-      travis_wait 30 cabal build
+      travis_wait 60 cabal build
 
       echo -e "\033[0;32mcabal test.\033[0m"
       cabal test

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ script:
       cabal configure --enable-tests
 
       echo -e "\033[0;32mcabal build.\033[0m"
-      cabal build
+      travis_wait 30 cabal build
 
       echo -e "\033[0;32mcabal test.\033[0m"
       cabal test


### PR DESCRIPTION
Closes #8.