### PR TITLE
Test for null trades, and fix the same issue with orders

### DIFF
--- a/src/Network/Bitcoin/BitX/Types/Internal.hs
+++ b/src/Network/Bitcoin/BitX/Types/Internal.hs
@@ -299,7 +299,7 @@ instance BitXAesRecordConvert Types.PrivateOrder where
 ------------------------------------------ PrivateOrders type --------------------------------------
 
 data PrivateOrders_ = PrivateOrders_
-    {privateOrders'orders :: [PrivateOrder_]
+    {privateOrders'orders :: Maybe [PrivateOrder_]
     }
 
 $(AesTH.deriveFromJSON AesTH.defaultOptions{AesTH.fieldLabelModifier = last . splitOn "'"}
@@ -308,7 +308,7 @@ $(AesTH.deriveFromJSON AesTH.defaultOptions{AesTH.fieldLabelModifier = last . sp
 instance BitXAesRecordConvert [Types.PrivateOrder] where
     type Aes [Types.PrivateOrder] = PrivateOrders_
     aesToRec PrivateOrders_ {..} =
-        map aesToRec privateOrders'orders
+        map aesToRec (fromMaybe [] privateOrders'orders)
 
 ------------------------------------------ OrderRequest type ---------------------------------------
 

--- a/test/Network/Bitcoin/BitX/Spec/Specs/AesonRecordSpec.hs
+++ b/test/Network/Bitcoin/BitX/Spec/Specs/AesonRecordSpec.hs
@@ -101,13 +101,18 @@ spec =
              privateOrderPair = XBTMYR,
              privateOrderState = COMPLETE,
              privateOrderOrderType = BID}
-    it "PrivateOrders is parsed properly" $
-      recordAesCheck
-        "{\"orders\":[{\"base\":\"568.7\", \"counter\":3764.2,\"creation_timestamp\":478873467, \
-            \ \"expiration_timestamp\":8768834222, \"completed_timestamp\":6511257825, \"fee_base\":\"3687.3\", \"fee_counter\":12.9,\
-            \ \"limit_price\":765.00,\"limit_volume\":55.2,\"order_id\":\"83YG\",\"pair\":\"XBTMYR\",\
-            \ \"state\":\"COMPLETE\",\"type\":\"BID\"}]}"
-        [privateOrderInner]
+    describe "PrivateOrders" $ do
+      it "PrivateOrders is parsed properly" $
+        recordAesCheck
+          "{\"orders\":[{\"base\":\"568.7\", \"counter\":3764.2,\"creation_timestamp\":478873467, \
+              \ \"expiration_timestamp\":8768834222, \"completed_timestamp\":6511257825, \"fee_base\":\"3687.3\", \"fee_counter\":12.9,\
+              \ \"limit_price\":765.00,\"limit_volume\":55.2,\"order_id\":\"83YG\",\"pair\":\"XBTMYR\",\
+              \ \"state\":\"COMPLETE\",\"type\":\"BID\"}]}"
+          [privateOrderInner]
+      it "parses null as an empty list" $
+        recordAesCheck
+          "{\"orders\":null}"
+          ([] :: [PrivateOrder])
     it "OrderID is parsed properly" $
       recordAesCheck
         "{\"order_id\":\"57983\"}"

--- a/test/Network/Bitcoin/BitX/Spec/Specs/AesonRecordSpec.hs
+++ b/test/Network/Bitcoin/BitX/Spec/Specs/AesonRecordSpec.hs
@@ -173,12 +173,17 @@ spec =
              privateTradeTimestamp = posixSecondsToUTCTime 1467138492.909,
              privateTradeOrderType = BID,
              privateTradeVolume = 0.147741}
-    it "PrivateTrades is parsed properly" $
-      recordAesCheck
-        "{\"trades\":[{\"base\": \"0.147741\", \"counter\": \"1549.950831\", \"fee_base\": \"0.90\", \"fee_counter\": \"0.00\", \
-            \ \"is_buy\": false, \"order_id\": \"BXMC2CJ7HNB88U4\", \"pair\": \"XBTZAR\", \"price\": \"10491.00\", \
-            \ \"timestamp\": 1467138492909, \"type\": \"BID\", \"volume\": \"0.147741\" }]}"
-         [privateTradeInner]
+    describe "PrivateTrades" $ do
+      it "parses a canned example correctly" $
+        recordAesCheck
+          "{\"trades\":[{\"base\": \"0.147741\", \"counter\": \"1549.950831\", \"fee_base\": \"0.90\", \"fee_counter\": \"0.00\", \
+              \ \"is_buy\": false, \"order_id\": \"BXMC2CJ7HNB88U4\", \"pair\": \"XBTZAR\", \"price\": \"10491.00\", \
+              \ \"timestamp\": 1467138492909, \"type\": \"BID\", \"volume\": \"0.147741\" }]}"
+           [privateTradeInner]
+      it "parses null as an empty list" $
+        recordAesCheck
+          "{\"trades\":null}"
+          ([] :: [PrivateTrade])
     it "FeeInfo is parsed properly" $
       recordAesCheck
         "{\"maker_fee\": \"0.00\", \"taker_fee\": \"0.10\", \"thirty_day_volume\": \"0.894342\"}"


### PR DESCRIPTION
Looks like `PrivateOrders` has the same issue where Luno will return `null` instead of an empty list.